### PR TITLE
🔧 Use bundle exec to ensure gems are scoped to the project

### DIFF
--- a/hosted/Procfile
+++ b/hosted/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
-release: rake release:postbuild
+release: bundle exec rake release:postbuild


### PR DESCRIPTION
Turns out I had not used bundle exec as part of the release command, which
causes the Procfile to crash out when launched on local machines.

This is... not particularly fine; because it can add a bit of friction as people start
getting set up to work on the project.