### PR TITLE
Add CJ to client list for next deploy in order to test out product.

### DIFF
--- a/hosted/app/models/client_builder.rb
+++ b/hosted/app/models/client_builder.rb
@@ -24,6 +24,11 @@ class ClientBuilder
       confirmation_message: "Thanks! We'll get back to you shortly!",
       support_staff: ["hello+wegotyourback@zincma.de"],
     },
+    {
+      name: "CJ Trial",
+      confirmation_message: "Thanks! We'll get back to you shortly!",
+      support_staff: ["cj@zinc.coop"],
+    }
   ]
 
   def populate


### PR DESCRIPTION
Didn't know whether the support_staff field could take two objects in the array so created a new hash. Let me know if I should just add another email to the Zinc support_field or if you prefer another option.