### PR TITLE
Let ActionMailer send email according to mailcatcher setup

### DIFF
--- a/hosted/config/environments/test.rb
+++ b/hosted/config/environments/test.rb
@@ -33,10 +33,11 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # Test intended to test for items in mailcatcher
+  # Setup mailer test environment according to mailcatcher doc
+  # https://github.com/sj26/mailcatcher#rails
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
`bin/test` failed because it wasn't sending email but our test was expecting mail send to mailcatcher.