### PR TITLE
Setup CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [ production ]
   pull_request:
-    branches: [ production ]
+    branches: [ '**' ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.6.3
+      uses: ruby/setup-ruby@v1 # reads from the project's `.ruby-version` file
+
     # Debug tool: https://github.com/marketplace/actions/debugging-with-tmate
     # - name: Setup tmate session
     #   uses: mxschmitt/action-tmate@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,5 +62,5 @@ jobs:
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake db:test:prepare
-        sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+        sudo Xvfb -ac $DISPLAY -screen 0 1280x1024x24 > /dev/null 2>&1 &
         bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ production ]
+  pull_request:
+    branches: [ production ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgres:11
+        env:
+          POSTGRES_USER: support_app_test
+          POSTGRES_PASSWORD: support_app_test
+          POSTGRES_DB: support_app_test
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6.3
+    # Debug tool: https://github.com/marketplace/actions/debugging-with-tmate
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v2
+
+    - name: Setup cache key and directory for gems cache
+      uses: actions/cache@v1.1.2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
+    - name: Mailcatcher setup
+      run: |
+        sudo apt-get install ruby-dev libsqlite3-dev
+        gem install mailcatcher --conservative
+        mailcatcher
+    - name: Build and run tests
+      env:
+        DATABASE_URL: postgres://support_app_test:support_app_test@localhost:5432/support_app_test
+        RAILS_ENV: test
+        DISPLAY: ':99'
+      run: |
+        cd hosted
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+        bundle exec rake db:test:prepare
+        sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+        bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Support
+![Test](https://github.com/zinc-collective/support/workflows/Ruby/badge.svg)
+
 Support is a hybrid hosted app/service as well as library solution for independent developers who want to provide a public inbox for receiving support requests without paying piles of money.
 
 ## Design

--- a/hosted/config/database.yml
+++ b/hosted/config/database.yml
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: support_app_test
+  url: <%= ENV.fetch('DATABASE_URL', 'postgresql://support_app_test:support_app_test@localhost:5432/support_app_test') %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/hosted/config/database.yml
+++ b/hosted/config/database.yml
@@ -57,7 +57,6 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  url: <%= ENV.fetch('DATABASE_URL', 'postgresql://support_app_test:support_app_test@localhost:5432/support_app_test') %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
Connects: https://github.com/zinc-collective/support/issues/34

Setup test on Github actions.
I was thinking I should use `bin/setup` & `bin/test` but it feels like it doesn't fit well, like I might had to do some if mac os, do this and if ubuntu to that?
Thoughts?

### Debug note (No longer valid if the tests are all green):

Not using `bin/setup` or `bin/test` to make things easier for now, will move these back to `bin`.

System test is failing, for some reason it can't launch `/usr/bin/google-chrome`
Got 
```[8156:8156:0528/031412.069785:ERROR:browser_main_loop.cc(1485)] Unable to open X display.```

After doing 
```
export DISPLAY=:1
Xvfb :1 -screen 0 1024x768x8&
```
Got 
```
Segmentation fault (core dumped)
```

Moved the above step in the same 'step` with the test and it passed, my guess is somehow the export statement doesn't carry to the next step.