### PR TITLE
WIP: scaffold for public schedule link.

### DIFF
--- a/hosted/app/assets/javascripts/schedules.js
+++ b/hosted/app/assets/javascripts/schedules.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/hosted/app/assets/stylesheets/schedules.css
+++ b/hosted/app/assets/stylesheets/schedules.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/hosted/app/controllers/schedules_controller.rb
+++ b/hosted/app/controllers/schedules_controller.rb
@@ -1,0 +1,2 @@
+class SchedulesController < ApplicationController
+end

--- a/hosted/app/helpers/schedules_helper.rb
+++ b/hosted/app/helpers/schedules_helper.rb
@@ -1,0 +1,2 @@
+module SchedulesHelper
+end

--- a/hosted/config/routes.rb
+++ b/hosted/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
 
   resources :inboxes, only: [:show]
   resources :inbound_messages, only: [:create, :show]
+  resources :team_members, param: :public_schedule_slug do
+    resources :schedules
+  end
 
   root "home#show"
 end

--- a/hosted/spec/controllers/schedules_controller_spec.rb
+++ b/hosted/spec/controllers/schedules_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SchedulesController, type: :controller do
+
+end

--- a/hosted/spec/helpers/schedules_helper_spec.rb
+++ b/hosted/spec/helpers/schedules_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SchedulesHelper. For example:
+#
+# describe SchedulesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SchedulesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
We're setting up public schedules for each team member using this route format:

- /team_members/:team_member_public_schedule_slug/schedules